### PR TITLE
Synchrotron Spectral Power Flux Plot

### DIFF
--- a/Plotting_Test/plotTest.jl
+++ b/Plotting_Test/plotTest.jl
@@ -6,3 +6,5 @@ mps = MyParamStruct(M8=0.1)
 
 # Test Synchrotron plot
 syncPlot(mps)
+
+print("Done!\n")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,5 +4,6 @@
 dn_e(γ, mps)
 j_syn(ϵ, mps)
 S_syn(ϵ, mps)
+P_syn(ϵ, mps)
 syncPlot(mps)
 ```

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -28,11 +28,11 @@ export MyParamStruct
     σ_T = 0.66524616E-24
     
     "Magnetic field strength in Gauss"
-    B = 1.5E-5      
+    B = 1.5E-5
     "Cyclotron energy in units of m_e*c^2"
-    ϵ_B = B/4.414E13    
+    ϵ_B = B/4.414E13
     "Magnetic field energy density"
-    u_B = B^2/8.0*pi   
+    u_B = B^2/8.0*pi
 
     # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
     "Normalisation of electron density"
@@ -47,13 +47,16 @@ export MyParamStruct
     z = 0.651
     "Bulk Lorentz factor"
     Γ = 10.0
-    "Angle between the direction of the blob's motion and the direction to the observer"
-    θ = 6.0
+    "Angle (radians) between the direction of the blob's motion and the direction to the observer"
+    θ = 6.0*pi/180.0
+    "Radius of emitting region"
+    radius = 1.0E22
 
     "Hubble parameter"
     ho = 0.67
     "Hublle constant in km s^-1 Mpc^-1"
-    Ho = 100.0*ho
+    # Ho = 100.0*ho
+    Ho = 50.0
     "Mass of BH in Solar Masses"
     M8 = 1.0E8
 end

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -2,6 +2,7 @@ module DiscJetConnections
 
 using Parameters
 using LaTeXStrings
+using HCubature
 using Plots
 gr()
 
@@ -27,27 +28,28 @@ export MyParamStruct
     σ_T = 0.66524616E-24
     
     "Magnetic field strength in Gauss"
-    B = 3.0E-6      
+    B = 1.5E-5      
     "Cyclotron energy in units of m_e*c^2"
     ϵ_B = B/4.414E13    
     "Magnetic field energy density"
     u_B = B^2/8.0*pi   
 
+    # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
     "Normalisation of electron density"
-    n_e0 = 500.0
+    n_e0 = 6E-5 # This value should not be bigger (not 500.0) but less
     "Power law index of electron distribution function"
-    p = 3.0            
+    p = 2.6             
     "Minimum Lorentz factor of electrons"
-    γ_min = 1.0E2      
+    γ_min = 10      
     "Maximum Lorentz factor of electrons"
-    γ_max = 1.0E7      
-
+    γ_max = 4.0E5      
     "Redshift"
-    z = 0.01
+    z = 0.651
     "Bulk Lorentz factor"
-    Γ = 2.6
+    Γ = 10.0
     "Angle between the direction of the blob's motion and the direction to the observer"
-    θ = 0.0
+    θ = 6.0
+
     "Hubble parameter"
     ho = 0.67
     "Hublle constant in km s^-1 Mpc^-1"

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -11,6 +11,8 @@ where
 ```math
 \\gamma_{min} \\le \\gamma \\le \\gamma_{max}
 ```
+see the equation 7.20 in Rybicki & Lightman 1979 (book)
+
 """
 function dn_e(γ, mps)
     if (γ < mps.γ_min) || (γ > mps.γ_max)
@@ -63,13 +65,31 @@ function S_syn(ϵ, mps)
     # Luminosity Distance dL(z)
     dL = (2.0*mps.c / mps.Ho) * (mps.z+1.0 - sqrt(mps.z+1.0))
 
-    # Volume of the blob (Sphere with radius R) Vb(R)
-    Rg = 1.5E13 * mps.M8
-    R = 10^3 * Rg
+    # Volume of the blob (Sphere with radius R in cm) Vb(R)
+    # Rg = 1.5E13 * mps.M8
+    # R = 10^3 * Rg
+    R = 1.0E22
     Vb = (4.0/3.0) * pi * R^3
 
     return((D^3 * (1.0+mps.z) * Vb * j_syn(ϵ*(1.0+mps.z)/D, mps)) / dL^2)
 end
+
+
+"""
+    P_syn(ϵ, mps)
+    
+Synchrotron Spectral Power Flux at observed photon energy `ϵ`.
+
+This is equivalent to \\nu F(\\nu) and presented in equation 23 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract).
+
+```math
+P_{syn}(\\epsilon, \\Omega; x) = \\epsilon  S_{syn}
+```
+"""
+function P_syn(ϵ, mps)
+    return(ϵ * S_syn(ϵ, mps))
+end
+
 
 """
     syncPlot(mps)
@@ -95,6 +115,7 @@ function syncPlot(mps)
     # Calculate S_syn values
     for i in eachindex(j_syn_values)
         nu = 10.0^log_nu[i]
+    # Calculate P_syn values
         # need to convert photon frequency to epsilon
         ϵ = mps.h*nu/(mps.m_e*mps.c^2)
         

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -57,18 +57,18 @@ function S_syn(ϵ, mps)
     # doppler factor D(Γ,θ)
     # Γ is the Bulk Lorentz Factor
     # Θ is the angle between the direction of the blob's motion and the direction to the observer
+    # B = 1 / β in the Dermer e tal. (1997) paper
     β = sqrt(1.0 - 1.0/mps.Γ^2)
     μ_obs = cos(mps.θ)
-    D = 1 / (mps.Γ*(1-(β * μ_obs)))
+    D = 1.0 / (mps.Γ*(1 - μ_obs/β))
     
     # Luminosity Distance dL(z)
-    dL = (2.0*mps.c / mps.Ho) * (mps.z+1.0 - sqrt(mps.z+1.0))
+    # Convert H_0 km / s / Mpc to cm / s / cm (cgs)
+    dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24 )) * (mps.z+1.0 - sqrt(mps.z+1.0))
 
-    # Volume of the blob (Sphere with radius R in cm) Vb(R)
+    # Volume of the blob (Sphere with radius in cm) Vb(R)
     # Rg = 1.5E13 * mps.M8
-    # R = 10^3 * Rg
-    R = 1.0E22
-    Vb = (4.0/3.0) * pi * R^3
+    Vb = (4.0/3.0) * pi * mps.radius^3
 
     return((D^3 * (1.0+mps.z) * Vb * j_syn(ϵ*(1.0+mps.z)/D, mps)) / dL^2)
 end
@@ -141,11 +141,11 @@ function syncPlot(mps)
 
     # Plotting the synchrotron spectral power flux  ~ νF(ν)
     plot(
-        log_nu, P_syn_values, label = L"\epsilon S_{syn} (\nu) \sim \nu F(\nu)", 
+        log_nu, P_syn_values, label = L"\nu S_{syn} (\nu)", 
         title = "Synchrotron spectral power flux", titlefontsize = 10, 
-        ylims=(22, 26), fmt=:jpg
+        ylims=(-16, -5), fmt=:jpg
         )
-    xlabel!(L"\log(\nu) - Hz")
-    ylabel!(L"\log(P_{syn}) - cgs")
+    xlabel!(L"\log(\nu) [Hz]")
+    ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
     #savefig("syn_spectral_power_flux.png")
 end

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -1,7 +1,7 @@
 """
     dn_e(γ, mps)
 
-Differential electron density at Lotentz factor `γ` for parameters `mps`.
+Differential electron density at Lorentz factor `γ` for parameters `mps`.
 
 The number of electrons with Lorentz factors in the range ``\\gamma`` to ``\\gamma + d\\gamma`` is given by ``dn_e``
 ```math
@@ -11,8 +11,7 @@ where
 ```math
 \\gamma_{min} \\le \\gamma \\le \\gamma_{max}
 ```
-see the equation 7.20 in Rybicki & Lightman 1979 (book)
-
+see also the equation 7.20 in [Rybicki and Lightman (1979)](https://ui.adsabs.harvard.edu/abs/1979rpa..book.....R/abstract)
 """
 function dn_e(γ, mps)
     if (γ < mps.γ_min) || (γ > mps.γ_max)
@@ -23,25 +22,25 @@ function dn_e(γ, mps)
     return dn_e
 end
 
+
 """
     j_syn(ϵ, mps)
 
 Synchrotron emissivity at photon energy `ϵ` for parameters `mps`.
 
-For an isotropic electron distribution in a randomly oriented magnetic field, the synchrotron emissivity is (see equation 13 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract) equation 13; we've changed their ``H`` to our ``B``)
+For an isotropic electron distribution in a randomly oriented magnetic field, the synchrotron emissivity is (see equation 13 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract); we've changed their ``H`` to our ``B``)
 
 ```math
 j_{syn}(\\epsilon, \\Omega; x) = \\frac{c \\sigma_T u_B}{6 \\pi \\epsilon_B} \\left( \\frac{\\epsilon}{\\epsilon_B} \\right)^{\\tiny{1/2}} \\small{n_e} \\left[ \\left( \\frac{\\epsilon}{\\epsilon_B}\\right)^{\\tiny{1/2}};x \\right]
 ```
-
-(more documentation here)
 """
 function j_syn(ϵ, mps)
     # need to convert photon frequency to characteristic lorentz factor gamma
     # *** this needs to be checked and understood - might be wrong! ***
     γ = sqrt(ϵ / mps.ϵ_B)
-    return ((mps.c*mps.σ_T*mps.u_B)/(6.0*pi*mps.ϵ_B)) * sqrt(ϵ/mps.ϵ_B) * dn_e(γ, mps)
+    return((mps.c*mps.σ_T*mps.u_B)/(6.0*pi*mps.ϵ_B)) * sqrt(ϵ/mps.ϵ_B) * dn_e(γ, mps)
 end
+
 
 """
     S_syn(ϵ, mps)
@@ -51,7 +50,7 @@ Synchrotron Flux Density at observed photon energy `ϵ`.
 This impliments equation 3 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract).
 
 ```math
-S_{syn}(\\epsilon, \\Omega; x) = \\frac{D^3 * (1+z) * Vb * j_{syn}}{dL^2}
+S_{syn}(\\epsilon, \\Omega; x) = \\frac{D^3 (1+z) V_b j_{syn}(\\frac{\\epsilon (1+z)}{D}, \\Omega; x)}{d_L^2}
 ```
 """
 function S_syn(ϵ, mps)
@@ -99,38 +98,54 @@ Example synchotron plot for parameters `mps`.
 function syncPlot(mps)
     # Set up an array of photon frequencies
     # log_10 low frequency 
-    log_nu_low = 9.0
+    log_nu_low = 7.0
     # log_10 high frequency
-    log_nu_high = 19.0
+    log_nu_high = 26.0
     # create log frequency array
     log_nu = range(log_nu_low, stop=log_nu_high, length=100)
     # Define the j_syn array as function of frequency
 
     # j_syn : synchrotron emissivity in ergs cm^-3 s^-1 sr^-1 epsilon^-1
     j_syn_values = zeros(length(log_nu))
-    # S_syn : synchrotron flux density in erg cm^-2 s^-1 sr^-1 epsilon^-1
+    # S_syn : synchrotron flux density in ergs cm^-2 s^-1 sr^-1 epsilon^-1
     S_syn_values = zeros(length(log_nu))
+    # P_syn : synchrotron spectral power flux in cgs units ergs cm^-2 s^-1 Hz^-1
+    P_syn_values = zeros(length(log_nu))
 
     # Calculate j_syn values
     # Calculate S_syn values
+    # Calculate P_syn values
     for i in eachindex(j_syn_values)
         nu = 10.0^log_nu[i]
-    # Calculate P_syn values
         # need to convert photon frequency to epsilon
         ϵ = mps.h*nu/(mps.m_e*mps.c^2)
         
         # print("gamma = ", gamma, " and epsilon = ", epsilon, " and epsilon_B = ", epsilon_B, "\n")
 
-        j_syn_values[i] = j_syn(ϵ, mps)
-        S_syn_values[i] = S_syn(ϵ, mps)
+        j_syn_values[i] = log10(j_syn(ϵ, mps))
+        S_syn_values[i] = log10(S_syn(ϵ, mps))
+        P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
     end
 
-    # Plotting the synchrotron emissivity or flux density
-    # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
+    # Plotting the synchrotron emissivity
+    # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", titlefontsize = 10, yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
     # xlabel!(L"\log_{10} (\nu)")
     # ylabel!(L"j_{syn}")
+    # savefig("syn_emissivity.png")
 
-    plot(log_nu, S_syn_values, label = L"S_{syn} (\nu)", title = "Synchrotron flux density", yaxis=:log10, xlims=(9, 19), ylims=(1.0E15, 1.0E24), fmt=:jpg)
-    xlabel!(L"\log_{10} (\nu)")
-    ylabel!(L"S_{syn}")
+    # Plotting the synchrotron flux density
+    # plot(log_nu, S_syn_values, label = L"\epsilon S_{syn} (\nu)", title = "Synchrotron Flux density", titlefontsize = 10, ylims=(-50, 50), fmt=:jpg)
+    # xlabel!(L"\log(\nu) - Hz")
+    # ylabel!(L"\log(S_{syn}) - cgs")
+    # savefig("syn_flux_density.png")
+
+    # Plotting the synchrotron spectral power flux  ~ νF(ν)
+    plot(
+        log_nu, P_syn_values, label = L"\epsilon S_{syn} (\nu) \sim \nu F(\nu)", 
+        title = "Synchrotron spectral power flux", titlefontsize = 10, 
+        ylims=(22, 26), fmt=:jpg
+        )
+    xlabel!(L"\log(\nu) - Hz")
+    ylabel!(L"\log(P_{syn}) - cgs")
+    #savefig("syn_spectral_power_flux.png")
 end


### PR DESCRIPTION
@phajy I added the synchrotron spectral power flux `P_syn = epsilon*S_syn ~ nu*F(nu)` calculation on the script and made some changes on the documentation. According our previous meeting, I need to test the code and tried to get similar plot as the figure 2 on [Tavecchio et al (2000)](https://ui.adsabs.harvard.edu/abs/2000ApJ...544L..23T/abstract). I got the following result. The shape is already there but I am not sure about the right values on the y-axis. 

![Tavecchio_Spectral_Power_Flux(1)](https://user-images.githubusercontent.com/100141757/168308745-8bb40ed4-407b-449c-8772-0137bf8d8df1.png)
#