### PR TITLE
Compton.jl

### DIFF
--- a/Plotting_Test/plotTest.jl
+++ b/Plotting_Test/plotTest.jl
@@ -7,4 +7,7 @@ mps = MyParamStruct(M8=0.1)
 # Test Synchrotron plot
 syncPlot(mps)
 
+# Test Synchrotron Self-Compton plot
+ssc_Plot(mps)
+
 print("Done!\n")

--- a/Plotting_Test/plotTest.jl
+++ b/Plotting_Test/plotTest.jl
@@ -6,3 +6,5 @@ mps = MyParamStruct(M8=0.1)
 
 # Test Synchrotron plot
 syncPlot(mps)
+
+print("Done!\n")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,5 +4,6 @@
 dn_e(γ, mps)
 j_syn(ϵ, mps)
 S_syn(ϵ, mps)
+P_syn(ϵ, mps)
 syncPlot(mps)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,5 @@
 # synchrotron.jl Documentation
+# Compton.jl Documentation
 
 ```@docs
 dn_e(γ, mps)
@@ -6,4 +7,7 @@ j_syn(ϵ, mps)
 S_syn(ϵ, mps)
 P_syn(ϵ, mps)
 syncPlot(mps)
+j_ssc(ϵ, mps)
+P_ssc(ϵ, mps)
+ssc_Plot(mps)
 ```

--- a/src/Compton.jl
+++ b/src/Compton.jl
@@ -1,0 +1,233 @@
+"""
+    j_ssc(ϵ, mps)
+
+Synchrotron Self-Compton (SSC) emissivity at photon energy `ϵ` for parameters `mps`.
+
+For an isotropic power-law electron distribution in a randomly oriented magnetic field, the first order SSC emissivity is given by the equation 20 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract)
+
+```math
+j_{SSC}(\\epsilon, \\Omega; x) = \\frac{c \\sigma_T^2 n_{e0}^2 u_B r_b}{9 \\pi \\epsilon_B} \\left( \\frac{\\epsilon}{\\epsilon_B} \\right)^{\\tiny{-\\alpha}} \\log{\\Sigma_C}
+```
+"""
+function j_ssc(ϵ, mps)
+    # need to convert photon frequency to characteristic lorentz factor gamma
+    # *** this needs to be checked and understood - might be wrong! ***
+    γ = sqrt(ϵ / mps.ϵ_B)
+
+    # α is the Spectral Index as a function of the power law index
+    α = (mps.p - 1) / 2
+
+    # Σ_c is the Compton synchrotron logarithm (see [Gould 1979](https://ui.adsabs.harvard.edu/abs/1979A%26A....76..306G/abstract))
+    Σ_c = min(ϵ^-1, ϵ/mps.γ_min^2, mps.ϵ_B*mps.γ_max^2) / max(mps.ϵ_B*mps.γ_min^2, ϵ/mps.γ_max^2)
+    
+    return(((mps.c * mps.σ_T^2 * mps.n_e0^2 * mps.u_B * mps.radius) / (9.0 * pi * mps.ϵ_B)) * (ϵ/mps.ϵ_B)^-α * log(Σ_c))
+end
+
+
+"""
+    P_ssc(ϵ, mps)
+    
+Synchrotron Self-Compton (SSC) Spectral Power Flux at observed photon energy `ϵ`.
+
+This is equivalent to \\nu F(\\nu) and presented in equation 24 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract).
+
+```math
+P_{syn}(\\epsilon, \\Omega; x) = D^(3+α) * \\frac{c \\sigma_T^2 n_{e0}^2 u_B r_b V_b}{9 \\pi d_L^2} \\left( 1+z \\right)^{1 - \\alpha} * \\left( \\frac{\\epsilon}{\\epsilon_B} \\right) \\ln{\\overline{\\Sigma_c}}
+```
+
+where \\ln{\\overline{\\Sigma_c}} is the transformed Compton-Synchrotron logarithm in equation 25
+
+"""
+# NOTE THAT THE CALCULATION OF THE SPECTRAL POWER FLUX HERE DOES NOT DEPEND ON THE EMISSIVITY 
+# I JUST USE DIRECTLY THE EQUATION 24 IN DERMER ET AL. 1997 PAPER
+function P_ssc(ϵ, mps)
+    # D(Γ,θ) Doppler factor
+    # Γ is the Bulk Lorentz Factor
+    # Θ is the angle between the direction of the blob's motion and the direction to the observer
+    β = sqrt(1.0 - 1.0/mps.Γ^2)
+    μ_obs = cos(mps.θ)
+    D = 1.0 / (mps.Γ*(1 - μ_obs*β))
+
+    # Need to convert photon frequency to characteristic lorentz factor gamma
+    γ = sqrt(ϵ / mps.ϵ_B)
+
+    # α is the Spectral Index as a function of the power law index
+    α = (mps.p - 1) / 2
+
+    # Luminosity Distance dL(z)
+    # Convert H_0 km / s / Mpc to cm / s / cm (cgs)
+    # dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24 )) * (mps.z+1.0 - sqrt(mps.z+1.0))
+    dL = 1.26E28  # This is the Luminosity Distance value for PKS 0637-752
+
+    # Volume of the blob (Sphere with radius in cm) Vb(R)
+    # Rg = 1.5E13 * mps.M8      # Rg is the Gravitational radius
+    # R = 10^3 Rg               # Size of blob calculation (see Dermer et al. 1997 paper) 
+    Vb = (4.0/3.0) * pi * mps.radius^3
+
+    # Σc is the transformed Compton synchrotron logarithm in EQUATION 25 of Dermer et al. 1997 paper
+    Σc = min(D/(ϵ*(1+mps.z)), mps.γ_max^2 * mps.ϵ_B, ϵ*(1+mps.z)/(D*mps.γ_min^2)) / max(mps.γ_min^2 * mps.ϵ_B, ϵ*(1+mps.z)/(D*mps.γ_max^2))
+
+    return((D^(3+α) * (mps.c*mps.σ_T^2*mps.n_e0^2*mps.u_B*mps.radius*Vb) * (1.0+mps.z)^(1-α) * (ϵ/mps.ϵ_B)^(1-α) * log(Σc)) / (9*pi*dL^2))
+end
+
+
+"""
+    ssc_Plot(mps)
+
+Example synchotron self-compton plot for parameters `mps`.
+"""
+function ssc_Plot(mps)
+    print("START SSC")
+    # Set up an array of photon frequencies
+    # log_10 low frequency 
+    log_nu_low = 7.0
+    # log_10 high frequency
+    log_nu_high = 26.0
+    # create log frequency array
+    log_nu = range(log_nu_low, stop=log_nu_high, length=100)
+    nu_values = zeros(length(log_nu))    # Frequency array in normal scales (Hz)
+
+    # Define the array as function of frequency
+    # Set up array for the emissivity and the spectral power flux
+    # j_ssc : synchrotron self-compton emissivity in ergs cm^-3 s^-1 sr^-1 epsilon^-1
+    j_ssc_values = zeros(length(log_nu))
+    # P_ssc : synchrotron spectral power flux in cgs units ergs cm^-2 s^-1 Hz^-1
+    P_ssc_values = zeros(length(log_nu))
+    
+    # Calculate j_ssc values
+    # Calculate P_ssc values
+    for i in eachindex(j_ssc_values)
+        nu = 10.0^log_nu[i]
+        nu_values[i] = log10(nu)     # Frequency values array (Hz) [This line might not really useful as it is already equal to log_nu define above]
+
+        # need to convert photon frequency to epsilon
+        ϵ = mps.h*nu/(mps.m_e*mps.c^2)
+
+        j_ssc_values[i] = (j_ssc(ϵ, mps))
+        P_ssc_values[i] = (P_ssc(ϵ, mps))
+    end
+
+    # Display the complete values for the synchrotron self-compton emissivity and the spectral power flux
+    print("\nj_ssc_1 = ", j_ssc_values)
+    print("\n---------------------------")
+    print("\nP_ssc_1 = ", P_ssc_values)
+
+    # VISUALIZATION I (j_ssc vs ν) & (P_ssc vs ν) normal scales
+    # Plotting the synchrotron self-Compton emissivity j_ssc
+    plot(
+        log_nu, j_ssc_values, label = L"j_{ssc} (\nu)", 
+        framestyle=:box, 
+        title = "Synchrotron self-compton emissivity", titlefontsize = 10,
+        xminorticks= 3, xlims=(6, 27), yminorticks=10, ylims=(-6.0E-22, 5.0E-23), fmt=:jpg)
+    xlabel!(L"\log_{10} (\nu)")
+    ylabel!(L"\log_{10} [j_{ssc} (\nu)]")
+    savefig("all_ssc_emissivity_all.png")
+    # ----
+    # Plotting the synchrotron self-Compton spectral power flux  ~ νF(ν) vs FREQUENCY
+    plot(
+        log_nu, P_ssc_values, label = L"\nu S_{syn} (\nu)",
+        framestyle=:box,     
+        title = "Synchrotron self-compton Spectral power Flux", titlefontsize = 10,
+        xminorticks= 3, xlims=(6, 27), yminorticks=10, ylims=(-2.0E-19, 2.0E-19), fmt=:jpg)
+    xlabel!(L"\log(\nu) [Hz]")
+    ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
+    savefig("all_syn_spectral_power_flux_FUNC_Frequency.png")
+
+    # POSITIVE VALUES Method I
+    # TAKE THE VALUES MANUALLY
+    Pos_nu_j = nu_values[41:87]
+    Pos_j_ssc_values = j_ssc_values[41:87]
+    Pos_nu_P = nu_values[46:92]
+    Pos_P_ssc_values = P_ssc_values[46:92]
+    logPos_j_ssc_values = zeros(length(Pos_nu_j))
+    logPos_P_ssc_values = zeros(length(Pos_nu_P))
+
+    for i in eachindex(Pos_j_ssc_values)
+        logPos_j_ssc_values[i] = log10(Pos_j_ssc_values[i])
+        logPos_P_ssc_values[i] = log10(Pos_P_ssc_values[i])
+    end
+    print("\n------------------------POSITIVE-VALUES-METHODE-I---------------------------------")
+    print("\nlogPos_j_ssc = ", logPos_j_ssc_values)
+    print("\n---------------------------")
+    print("\nlogPos_P_ssc = ", logPos_P_ssc_values)
+
+    # VISUALIZATION II (j_ssc vs ν) & (P_ssc vs ν) log scales method 1
+    # Plotting the synchrotron self-Compton emissivity j_ssc
+    plot(
+        Pos_nu_j, logPos_j_ssc_values, label = L"j_{ssc} (\nu)", 
+        framestyle=:box, 
+        title = "Synchrotron self-compton emissivity", titlefontsize = 10,
+        xminorticks= 3, xlims=(6, 27), yminorticks=10, ylims=(-37, -29), fmt=:jpg)
+    xlabel!(L"\log_{10} (\nu)")
+    ylabel!(L"\log_{10} [j_{ssc} (\nu)]")
+    savefig("I_ssc_emissivity.png")
+    # ----
+    # Plotting the synchrotron self-Compton spectral power flux  ~ νF(ν) vs FREQUENCY
+    plot(
+        Pos_nu_P, logPos_P_ssc_values, label = L"\nu S_{syn} (\nu)",
+        framestyle=:box,     
+        title = "Synchrotron self-compton Spectral power Flux", titlefontsize = 10,
+        xminorticks= 3, xlims=(6, 27), yminorticks=10, ylims=(-22, -18), fmt=:jpg)
+    xlabel!(L"\log(\nu) [Hz]")
+    ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
+    savefig("I_ssc_spectral_power_flux_FUNC_Frequency.png")
+
+
+    # POSITIVE VALUES Method II
+    log_j_ssc_values_2 = zeros(length(log_nu))
+    j_ssc_values_2 = j_ssc_values
+    for i in eachindex(j_ssc_values_2)
+        if j_ssc_values_2[i] <= 0
+            j_ssc_values_2[i] = 1
+        else
+            j_ssc_values_2[i] = j_ssc_values_2[i]
+        end
+        log_j_ssc_values_2[i] = log10(j_ssc_values_2[i])
+    end
+
+    log_P_ssc_values_2 = zeros(length(log_nu))
+    P_ssc_values_2 = P_ssc_values
+    for i in eachindex(P_ssc_values_2)
+        if P_ssc_values_2[i] <= 0
+            P_ssc_values_2[i] = 1
+        else
+            P_ssc_values_2[i] = P_ssc_values_2[i]
+        end
+        log_P_ssc_values_2[i] = log10(P_ssc_values_2[i])
+    end
+
+    print("\n-----------------------POSITIVE-VALUES-METHODE-II------------------------------")
+    print("\nj_ssc_2 = ", j_ssc_values_2)
+    print("\n---------------------------")
+    print("\nP_ssc_2 = ", P_ssc_values_2)
+    print("\n---------------------------")
+    print("\nLog_j_ssc_2 = ", log_j_ssc_values_2)
+    print("\n---------------------------")
+    print("\nLog_P_ssc_2 = ", log_P_ssc_values_2)
+
+    # VISUALIZATION III (j_ssc vs ν) & (P_ssc vs ν) log scales method 2
+    # Plotting the synchrotron self-Compton emissivity j_ssc
+    plot(
+        log_nu, log_j_ssc_values_2, label = L"j_{ssc} (\nu)", 
+        framestyle=:box, 
+        title = "Synchrotron self-compton emissivity", titlefontsize = 10,
+        xminorticks= 3, xlims=(6, 27), yminorticks=10, ylims=(-37, 0), fmt=:jpg)
+    xlabel!(L"\log_{10} (\nu)")
+    ylabel!(L"\log_{10} [j_{ssc} (\nu)]")
+    savefig("II_ssc_emissivity.png")
+    # ----
+    # Plotting the synchrotron self-Compton spectral power flux  ~ νF(ν) vs FREQUENCY
+    plot(
+        log_nu, log_P_ssc_values_2, label = L"\nu S_{syn} (\nu)",
+        framestyle=:box,     
+        title = "Synchrotron self-compton Spectral power Flux", titlefontsize = 10,
+        xminorticks= 3, xlims=(6, 27), yminorticks=10, ylims=(-22, 0), fmt=:jpg)
+    xlabel!(L"\log(\nu) [Hz]")
+    ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
+    savefig("II_ssc_spectral_power_flux_FUNC_Frequency.png")
+
+    print("\nEND SSC")
+
+    # TRY TO USE SUBPLOT TO DISPLAY ALL THE PLOTS. JUST WONDERING WHAT IS THE BEST WHY IN JULIA?
+
+end

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -35,29 +35,29 @@ export MyParamStruct
     "Magnetic field energy density"
     u_B = B^2/8.0*pi
 
-    # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
+    # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000 or Uchiyama et al. 2005
     "Normalisation of electron density"
     n_e0 = 6.0E-5 # This value should not be bigger (not 500.0) but less
     "Power law index of electron distribution function"
-    p = 2.6             
+    p = 2.7             
     "Minimum Lorentz factor of electrons"
-    γ_min = 10      
+    γ_min = 1.78E3  # Calculated using the expression in section 3.1 Uchiyama et al. 2005
     "Maximum Lorentz factor of electrons"
-    γ_max = 4.0E5      
+    γ_max = 3.21E5  # Calculated using the expression in section 3.1 Uchiyama et al. 2005
     "Redshift"
     z = 0.651
     "Bulk Lorentz factor"
-    Γ = 10.0
+    Γ = 12.0
     "Angle (radians) between the direction of the blob's motion and the direction to the observer"
-    θ = 6.0*pi/180.0
+    θ = 3.5*pi/180.0
     "Radius of emitting region"
-    radius = 1.0E22
+    radius = 3.086E21
 
     "Hubble parameter"
     ho = 0.67
     "Hublle constant in km s^-1 Mpc^-1"
     # Ho = 100.0*ho
-    Ho = 50.0
+    Ho = 71.0
     "Mass of BH in Solar Masses"
     M8 = 1.0E8
 end

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -4,13 +4,17 @@ using Parameters
 using LaTeXStrings
 using HCubature
 using Plots
-gr()
+gr()   # default backend for Plots
 
 export dn_e
 export j_syn
 export S_syn
 export P_syn
 export syncPlot
+
+export j_ssc
+export P_ssc
+export ssc_Plot
 
 export MyParamStruct
 
@@ -37,7 +41,7 @@ export MyParamStruct
 
     # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000 or Uchiyama et al. 2005
     "Normalisation of electron density"
-    n_e0 = 6.0E-5 # This value should not be bigger (not 500.0) but less
+    n_e0 = 6E-5 # This value should not be bigger (not 500.0) but less
     "Power law index of electron distribution function"
     p = 2.7             
     "Minimum Lorentz factor of electrons"
@@ -63,5 +67,6 @@ export MyParamStruct
 end
 
 include("synchrotron.jl")
+include("Compton.jl")
 
 end # module

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -28,11 +28,11 @@ export MyParamStruct
     σ_T = 0.66524616E-24
     
     "Magnetic field strength in Gauss"
-    B = 1.5E-5      
+    B = 1.5E-5
     "Cyclotron energy in units of m_e*c^2"
-    ϵ_B = B/4.414E13    
+    ϵ_B = B/4.414E13
     "Magnetic field energy density"
-    u_B = B^2/8.0*pi   
+    u_B = B^2/8.0*pi
 
     # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
     "Normalisation of electron density"
@@ -47,13 +47,16 @@ export MyParamStruct
     z = 0.651
     "Bulk Lorentz factor"
     Γ = 10.0
-    "Angle between the direction of the blob's motion and the direction to the observer"
-    θ = 6.0
+    "Angle (radians) between the direction of the blob's motion and the direction to the observer"
+    θ = 6.0*pi/180.0
+    "Radius of emitting region"
+    radius = 1.0E22
 
     "Hubble parameter"
     ho = 0.67
     "Hublle constant in km s^-1 Mpc^-1"
-    Ho = 100.0*ho
+    # Ho = 100.0*ho
+    Ho = 50.0
     "Mass of BH in Solar Masses"
     M8 = 1.0E8
 end

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -31,7 +31,6 @@ export MyParamStruct
     "Magnetic field strength in Gauss"
     B = 1.5E-5      
     "Cyclotron energy in units of m_e*c^2"
-    #ϵ_B = m_e*c^2
     ϵ_B = B/4.414E13    # Dermer 1995 below eq.8
     "Magnetic field energy density"
     u_B = B^2/8.0*pi   

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -9,6 +9,7 @@ gr()
 export dn_e
 export j_syn
 export S_syn
+export P_syn
 export syncPlot
 
 export MyParamStruct
@@ -30,13 +31,14 @@ export MyParamStruct
     "Magnetic field strength in Gauss"
     B = 1.5E-5      
     "Cyclotron energy in units of m_e*c^2"
-    ϵ_B = B/4.414E13    
+    #ϵ_B = m_e*c^2
+    ϵ_B = B/4.414E13    # Dermer 1995 below eq.8
     "Magnetic field energy density"
     u_B = B^2/8.0*pi   
 
     # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
     "Normalisation of electron density"
-    n_e0 = 6E-5 # This value should not be bigger (not 500.0) but less
+    n_e0 = 6.0E-5 # This value should not be bigger (not 500.0) but less
     "Power law index of electron distribution function"
     p = 2.6             
     "Minimum Lorentz factor of electrons"
@@ -47,12 +49,15 @@ export MyParamStruct
     z = 0.651
     "Bulk Lorentz factor"
     Γ = 10.0
-    "Angle between the direction of the blob's motion and the direction to the observer"
-    θ = 6.0
+    "Angle (radians) between the direction of the blob's motion and the direction to the observer"
+    θ = 6.0*pi/180.0
+    "Radius of emitting region"
+    radius = 1.0E22
 
     "Hubble parameter"
     ho = 0.67
     "Hublle constant in km s^-1 Mpc^-1"
+    # Ho = 100.0*ho
     Ho = 100.0*ho
     "Mass of BH in Solar Masses"
     M8 = 1.0E8

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -29,11 +29,11 @@ export MyParamStruct
     σ_T = 0.66524616E-24
     
     "Magnetic field strength in Gauss"
-    B = 1.5E-5      
+    B = 1.5E-5  
     "Cyclotron energy in units of m_e*c^2"
     ϵ_B = B/4.414E13    # Dermer 1995 below eq.8
     "Magnetic field energy density"
-    u_B = B^2/8.0*pi   
+    u_B = B^2/8.0*pi
 
     # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
     "Normalisation of electron density"

--- a/src/DiscJetConnections.jl
+++ b/src/DiscJetConnections.jl
@@ -2,6 +2,7 @@ module DiscJetConnections
 
 using Parameters
 using LaTeXStrings
+using HCubature
 using Plots
 gr()
 
@@ -27,27 +28,28 @@ export MyParamStruct
     σ_T = 0.66524616E-24
     
     "Magnetic field strength in Gauss"
-    B = 3.0E-6      
+    B = 1.5E-5      
     "Cyclotron energy in units of m_e*c^2"
     ϵ_B = B/4.414E13    
     "Magnetic field energy density"
     u_B = B^2/8.0*pi   
 
+    # PKS0637-752: Values taken from Schwartz et al. 2000 or Tavecchio et al. 2000
     "Normalisation of electron density"
-    n_e0 = 500.0
+    n_e0 = 6E-5 # This value should not be bigger (not 500.0) but less
     "Power law index of electron distribution function"
-    p = 3.0            
+    p = 2.6             
     "Minimum Lorentz factor of electrons"
-    γ_min = 1.0E2      
+    γ_min = 10      
     "Maximum Lorentz factor of electrons"
-    γ_max = 1.0E7      
-
+    γ_max = 4.0E5      
     "Redshift"
-    z = 0.01
+    z = 0.651
     "Bulk Lorentz factor"
-    Γ = 2.6
+    Γ = 10.0
     "Angle between the direction of the blob's motion and the direction to the observer"
-    θ = 0.0
+    θ = 6.0
+
     "Hubble parameter"
     ho = 0.67
     "Hublle constant in km s^-1 Mpc^-1"

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -11,6 +11,8 @@ where
 ```math
 \\gamma_{min} \\le \\gamma \\le \\gamma_{max}
 ```
+see the equation 7.20 in Rybicki & Lightman 1979 (book)
+
 """
 function dn_e(γ, mps)
     if (γ < mps.γ_min) || (γ > mps.γ_max)
@@ -63,13 +65,31 @@ function S_syn(ϵ, mps)
     # Luminosity Distance dL(z)
     dL = (2.0*mps.c / mps.Ho) * (mps.z+1.0 - sqrt(mps.z+1.0))
 
-    # Volume of the blob (Sphere with radius R) Vb(R)
-    Rg = 1.5E13 * mps.M8
-    R = 10^3 * Rg
+    # Volume of the blob (Sphere with radius R in cm) Vb(R)
+    # Rg = 1.5E13 * mps.M8
+    # R = 10^3 * Rg
+    R = 1.0E22
     Vb = (4.0/3.0) * pi * R^3
 
     return((D^3 * (1.0+mps.z) * Vb * j_syn(ϵ*(1.0+mps.z)/D, mps)) / dL^2)
 end
+
+
+"""
+    P_syn(ϵ, mps)
+    
+Synchrotron Spectral Power Flux at observed photon energy `ϵ`.
+
+This is equivalent to \\nu F(\\nu) and presented in equation 23 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract).
+
+```math
+P_{syn}(\\epsilon, \\Omega; x) = \\epsilon  S_{syn}
+```
+"""
+function P_syn(ϵ, mps)
+    return(ϵ * S_syn(ϵ, mps))
+end
+
 
 """
     syncPlot(mps)
@@ -95,6 +115,7 @@ function syncPlot(mps)
     # Calculate S_syn values
     for i in eachindex(j_syn_values)
         nu = 10.0^log_nu[i]
+    # Calculate P_syn values
         # need to convert photon frequency to epsilon
         ϵ = mps.h*nu/(mps.m_e*mps.c^2)
         

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -126,7 +126,7 @@ function syncPlot(mps)
         S_syn_values[i] = log10(S_syn(ϵ, mps))
         P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
     end
-    
+
     # Plotting the synchrotron emissivity
     # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", titlefontsize = 10, yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
     # xlabel!(L"\log_{10} (\nu)")

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -126,6 +126,7 @@ function syncPlot(mps)
         S_syn_values[i] = log10(S_syn(ϵ, mps))
         P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
     end
+    print(P_syn_values)
     
     # Plotting the synchrotron emissivity
     # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", titlefontsize = 10, yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
@@ -143,7 +144,7 @@ function syncPlot(mps)
     plot(
         log_nu, P_syn_values, label = L"\epsilon S_{syn} (\nu) \sim \nu F(\nu)", 
         title = "Synchrotron spectral power flux", titlefontsize = 10, 
-        ylims=(22, 26), fmt=:jpg
+        ylims=(-16, -5), fmt=:jpg
         )
     xlabel!(L"\log(\nu) - Hz")
     ylabel!(L"\log(P_{syn}) - cgs")

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -126,7 +126,7 @@ function syncPlot(mps)
         S_syn_values[i] = log10(S_syn(ϵ, mps))
         P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
     end
-
+    
     # Plotting the synchrotron emissivity
     # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", titlefontsize = 10, yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
     # xlabel!(L"\log_{10} (\nu)")

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -57,18 +57,18 @@ function S_syn(ϵ, mps)
     # doppler factor D(Γ,θ)
     # Γ is the Bulk Lorentz Factor
     # Θ is the angle between the direction of the blob's motion and the direction to the observer
+    # B = 1 / β in the Dermer e tal. (1997) paper
     β = sqrt(1.0 - 1.0/mps.Γ^2)
     μ_obs = cos(mps.θ)
-    D = 1 / (mps.Γ*(1-(β * μ_obs)))
+    D = 1.0 / (mps.Γ*(1 - μ_obs/β))
     
     # Luminosity Distance dL(z)
-    dL = (2.0*mps.c / mps.Ho) * (mps.z+1.0 - sqrt(mps.z+1.0))
+    # Convert H_0 km / s / Mpc to cm / s / cm (cgs)
+    dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24 )) * (mps.z+1.0 - sqrt(mps.z+1.0))
 
-    # Volume of the blob (Sphere with radius R in cm) Vb(R)
+    # Volume of the blob (Sphere with radius in cm) Vb(R)
     # Rg = 1.5E13 * mps.M8
-    # R = 10^3 * Rg
-    R = 1.0E22
-    Vb = (4.0/3.0) * pi * R^3
+    Vb = (4.0/3.0) * pi * mps.radius^3
 
     return((D^3 * (1.0+mps.z) * Vb * j_syn(ϵ*(1.0+mps.z)/D, mps)) / dL^2)
 end
@@ -141,11 +141,11 @@ function syncPlot(mps)
 
     # Plotting the synchrotron spectral power flux  ~ νF(ν)
     plot(
-        log_nu, P_syn_values, label = L"\epsilon S_{syn} (\nu) \sim \nu F(\nu)", 
+        log_nu, P_syn_values, label = L"\nu S_{syn} (\nu)", 
         title = "Synchrotron spectral power flux", titlefontsize = 10, 
-        ylims=(22, 26), fmt=:jpg
+        ylims=(-16, -5), fmt=:jpg
         )
-    xlabel!(L"\log(\nu) - Hz")
-    ylabel!(L"\log(P_{syn}) - cgs")
+    xlabel!(L"\log(\nu) [Hz]")
+    ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
     #savefig("syn_spectral_power_flux.png")
 end

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -1,7 +1,7 @@
 """
     dn_e(γ, mps)
 
-Differential electron density at Lotentz factor `γ` for parameters `mps`.
+Differential electron density at Lorentz factor `γ` for parameters `mps`.
 
 The number of electrons with Lorentz factors in the range ``\\gamma`` to ``\\gamma + d\\gamma`` is given by ``dn_e``
 ```math
@@ -11,8 +11,7 @@ where
 ```math
 \\gamma_{min} \\le \\gamma \\le \\gamma_{max}
 ```
-see the equation 7.20 in Rybicki & Lightman 1979 (book)
-
+see also the equation 7.20 in [Rybicki and Lightman (1979)](https://ui.adsabs.harvard.edu/abs/1979rpa..book.....R/abstract)
 """
 function dn_e(γ, mps)
     if (γ < mps.γ_min) || (γ > mps.γ_max)
@@ -23,25 +22,25 @@ function dn_e(γ, mps)
     return dn_e
 end
 
+
 """
     j_syn(ϵ, mps)
 
 Synchrotron emissivity at photon energy `ϵ` for parameters `mps`.
 
-For an isotropic electron distribution in a randomly oriented magnetic field, the synchrotron emissivity is (see equation 13 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract) equation 13; we've changed their ``H`` to our ``B``)
+For an isotropic electron distribution in a randomly oriented magnetic field, the synchrotron emissivity is (see equation 13 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract); we've changed their ``H`` to our ``B``)
 
 ```math
 j_{syn}(\\epsilon, \\Omega; x) = \\frac{c \\sigma_T u_B}{6 \\pi \\epsilon_B} \\left( \\frac{\\epsilon}{\\epsilon_B} \\right)^{\\tiny{1/2}} \\small{n_e} \\left[ \\left( \\frac{\\epsilon}{\\epsilon_B}\\right)^{\\tiny{1/2}};x \\right]
 ```
-
-(more documentation here)
 """
 function j_syn(ϵ, mps)
     # need to convert photon frequency to characteristic lorentz factor gamma
     # *** this needs to be checked and understood - might be wrong! ***
     γ = sqrt(ϵ / mps.ϵ_B)
-    return ((mps.c*mps.σ_T*mps.u_B)/(6.0*pi*mps.ϵ_B)) * sqrt(ϵ/mps.ϵ_B) * dn_e(γ, mps)
+    return((mps.c*mps.σ_T*mps.u_B)/(6.0*pi*mps.ϵ_B)) * sqrt(ϵ/mps.ϵ_B) * dn_e(γ, mps)
 end
+
 
 """
     S_syn(ϵ, mps)
@@ -51,7 +50,7 @@ Synchrotron Flux Density at observed photon energy `ϵ`.
 This impliments equation 3 of [Dermer et al. (1997)](https://ui.adsabs.harvard.edu/abs/1997ApJS..109..103D/abstract).
 
 ```math
-S_{syn}(\\epsilon, \\Omega; x) = \\frac{D^3 * (1+z) * Vb * j_{syn}}{dL^2}
+S_{syn}(\\epsilon, \\Omega; x) = \\frac{D^3 (1+z) V_b j_{syn}(\\frac{\\epsilon (1+z)}{D}, \\Omega; x)}{d_L^2}
 ```
 """
 function S_syn(ϵ, mps)
@@ -99,38 +98,54 @@ Example synchotron plot for parameters `mps`.
 function syncPlot(mps)
     # Set up an array of photon frequencies
     # log_10 low frequency 
-    log_nu_low = 9.0
+    log_nu_low = 7.0
     # log_10 high frequency
-    log_nu_high = 19.0
+    log_nu_high = 26.0
     # create log frequency array
     log_nu = range(log_nu_low, stop=log_nu_high, length=100)
     # Define the j_syn array as function of frequency
 
     # j_syn : synchrotron emissivity in ergs cm^-3 s^-1 sr^-1 epsilon^-1
     j_syn_values = zeros(length(log_nu))
-    # S_syn : synchrotron flux density in erg cm^-2 s^-1 sr^-1 epsilon^-1
+    # S_syn : synchrotron flux density in ergs cm^-2 s^-1 sr^-1 epsilon^-1
     S_syn_values = zeros(length(log_nu))
+    # P_syn : synchrotron spectral power flux in cgs units ergs cm^-2 s^-1 Hz^-1
+    P_syn_values = zeros(length(log_nu))
 
     # Calculate j_syn values
     # Calculate S_syn values
+    # Calculate P_syn values
     for i in eachindex(j_syn_values)
         nu = 10.0^log_nu[i]
-    # Calculate P_syn values
         # need to convert photon frequency to epsilon
         ϵ = mps.h*nu/(mps.m_e*mps.c^2)
         
         # print("gamma = ", gamma, " and epsilon = ", epsilon, " and epsilon_B = ", epsilon_B, "\n")
 
-        j_syn_values[i] = j_syn(ϵ, mps)
-        S_syn_values[i] = S_syn(ϵ, mps)
+        j_syn_values[i] = log10(j_syn(ϵ, mps))
+        S_syn_values[i] = log10(S_syn(ϵ, mps))
+        P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
     end
 
-    # Plotting the synchrotron emissivity or flux density
-    # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
+    # Plotting the synchrotron emissivity
+    # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", titlefontsize = 10, yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
     # xlabel!(L"\log_{10} (\nu)")
     # ylabel!(L"j_{syn}")
+    # savefig("syn_emissivity.png")
 
-    plot(log_nu, S_syn_values, label = L"S_{syn} (\nu)", title = "Synchrotron flux density", yaxis=:log10, xlims=(9, 19), ylims=(1.0E15, 1.0E24), fmt=:jpg)
-    xlabel!(L"\log_{10} (\nu)")
-    ylabel!(L"S_{syn}")
+    # Plotting the synchrotron flux density
+    # plot(log_nu, S_syn_values, label = L"\epsilon S_{syn} (\nu)", title = "Synchrotron Flux density", titlefontsize = 10, ylims=(-50, 50), fmt=:jpg)
+    # xlabel!(L"\log(\nu) - Hz")
+    # ylabel!(L"\log(S_{syn}) - cgs")
+    # savefig("syn_flux_density.png")
+
+    # Plotting the synchrotron spectral power flux  ~ νF(ν)
+    plot(
+        log_nu, P_syn_values, label = L"\epsilon S_{syn} (\nu) \sim \nu F(\nu)", 
+        title = "Synchrotron spectral power flux", titlefontsize = 10, 
+        ylims=(22, 26), fmt=:jpg
+        )
+    xlabel!(L"\log(\nu) - Hz")
+    ylabel!(L"\log(P_{syn}) - cgs")
+    #savefig("syn_spectral_power_flux.png")
 end

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -57,16 +57,7 @@ function S_syn(ϵ, mps)
     # doppler factor D(Γ,θ)
     # Γ is the Bulk Lorentz Factor
     # Θ is the angle between the direction of the blob's motion and the direction to the observer
-    # B = 1/β in the Dermer et al. (1997) paper
-    β = sqrt(1.0 - 1.0/mps.Γ^2)
-    μ_obs = cos(mps.θ)
-    D = 1.0 / (mps.Γ*(1-(μ_obs/β)))
-    
-    # Luminosity Distance dL(z)
-    # Convert H_0 km / s / Mpc to cm / s / cm (cgs)
-    dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24)) * (mps.z+1.0 - sqrt(mps.z+1.0))
-
-    # B = 1 / β in the Dermer e tal. (1997) paper
+    # B = 1 / β in the Dermer et al. (1997) paper
     β = sqrt(1.0 - 1.0/mps.Γ^2)
     μ_obs = cos(mps.θ)
     D = 1.0 / (mps.Γ*(1 - μ_obs/β))

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -57,18 +57,18 @@ function S_syn(ϵ, mps)
     # doppler factor D(Γ,θ)
     # Γ is the Bulk Lorentz Factor
     # Θ is the angle between the direction of the blob's motion and the direction to the observer
+    # B = 1/β in the Dermer et al. (1997) paper
     β = sqrt(1.0 - 1.0/mps.Γ^2)
     μ_obs = cos(mps.θ)
-    D = 1 / (mps.Γ*(1-(β * μ_obs)))
+    D = 1.0 / (mps.Γ*(1-(μ_obs/β)))
     
     # Luminosity Distance dL(z)
-    dL = (2.0*mps.c / mps.Ho) * (mps.z+1.0 - sqrt(mps.z+1.0))
+    # Convert H_0 km / s / Mpc to cm / s / cm (cgs)
+    dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24)) * (mps.z+1.0 - sqrt(mps.z+1.0))
 
     # Volume of the blob (Sphere with radius R in cm) Vb(R)
     # Rg = 1.5E13 * mps.M8
-    # R = 10^3 * Rg
-    R = 1.0E22
-    Vb = (4.0/3.0) * pi * R^3
+    Vb = (4.0/3.0) * pi * mps.radius^3
 
     return((D^3 * (1.0+mps.z) * Vb * j_syn(ϵ*(1.0+mps.z)/D, mps)) / dL^2)
 end
@@ -126,7 +126,6 @@ function syncPlot(mps)
         S_syn_values[i] = log10(S_syn(ϵ, mps))
         P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
     end
-    print(P_syn_values)
     
     # Plotting the synchrotron emissivity
     # plot(log_nu, j_syn_values, label = L"j_{syn} (nu)", title = "Synchrotron emissivity", titlefontsize = 10, yaxis=:log10, xlims=(9, 19), ylims=(1.0E-20, 1.0E-12), fmt=:jpg)
@@ -146,7 +145,7 @@ function syncPlot(mps)
         title = "Synchrotron spectral power flux", titlefontsize = 10, 
         ylims=(-16, -5), fmt=:jpg
         )
-    xlabel!(L"\log(\nu) - Hz")
-    ylabel!(L"\log(P_{syn}) - cgs")
+    xlabel!(L"\log(\nu) [Hz]")
+    ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
     #savefig("syn_spectral_power_flux.png")
 end

--- a/src/synchrotron.jl
+++ b/src/synchrotron.jl
@@ -60,12 +60,12 @@ function S_syn(ϵ, mps)
     # B = 1 / β in the Dermer et al. (1997) paper
     β = sqrt(1.0 - 1.0/mps.Γ^2)
     μ_obs = cos(mps.θ)
-    D = 1.0 / (mps.Γ*(1 - μ_obs/β))
+    D = 1.0 / (mps.Γ*(1 - μ_obs*β))
     
     # Luminosity Distance dL(z)
     # Convert H_0 km / s / Mpc to cm / s / cm (cgs)
-    dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24 )) * (mps.z+1.0 - sqrt(mps.z+1.0))
-
+    #dL = (2.0*mps.c / (mps.Ho * 1.0E5 / 3.086E24 )) * (mps.z+1.0 - sqrt(mps.z+1.0))
+    dL = 1.26E28
     # Volume of the blob (Sphere with radius in cm) Vb(R)
     # Rg = 1.5E13 * mps.M8
     Vb = (4.0/3.0) * pi * mps.radius^3
@@ -111,7 +111,9 @@ function syncPlot(mps)
     S_syn_values = zeros(length(log_nu))
     # P_syn : synchrotron spectral power flux in cgs units ergs cm^-2 s^-1 Hz^-1
     P_syn_values = zeros(length(log_nu))
-
+    # Energy : E=hν (Define the x-axis to the energy in [ergs], try to produce fig2 in Uchiyama et al 2005)
+    Energy = zeros(length(log_nu))
+    
     # Calculate j_syn values
     # Calculate S_syn values
     # Calculate P_syn values
@@ -121,10 +123,10 @@ function syncPlot(mps)
         ϵ = mps.h*nu/(mps.m_e*mps.c^2)
         
         # print("gamma = ", gamma, " and epsilon = ", epsilon, " and epsilon_B = ", epsilon_B, "\n")
-
-        j_syn_values[i] = log10(j_syn(ϵ, mps))
-        S_syn_values[i] = log10(S_syn(ϵ, mps))
-        P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps))
+        Energy[i] = (mps.h*nu / 1.602E-12) # energy in [eV]
+        j_syn_values[i] = log10(j_syn(ϵ, mps)) # ERASE THE LOG10 TO GET THE PLOT WITH ENERGY X-AXIS
+        S_syn_values[i] = log10(S_syn(ϵ, mps)) # ERASE THE LOG10 TO GET THE PLOT WITH ENERGY X-AXIS
+        P_syn_values[i] = log10(ϵ*S_syn(ϵ, mps)) # ERASE THE LOG10 TO GET THE PLOT WITH ENERGY X-AXIS
     end
 
     # Plotting the synchrotron emissivity
@@ -139,13 +141,23 @@ function syncPlot(mps)
     # ylabel!(L"\log(S_{syn}) - cgs")
     # savefig("syn_flux_density.png")
 
-    # Plotting the synchrotron spectral power flux  ~ νF(ν)
+    # Plotting the synchrotron spectral power flux  ~ νF(ν) vs FREQUENCY
     plot(
         log_nu, P_syn_values, label = L"\nu S_{syn} (\nu)", 
         title = "Synchrotron spectral power flux", titlefontsize = 10, 
-        ylims=(-16, -5), fmt=:jpg
+        ylims=(-16, -12), xlims=(7, 26), fmt=:jpg
         )
     xlabel!(L"\log(\nu) [Hz]")
     ylabel!(L"\log(\nu S_{syn} (\nu)) [cgs]")
-    #savefig("syn_spectral_power_flux.png")
+    #savefig("syn_spectral_power_flux_FUNC_Frequency.png")
+
+    # Plotting the synchrotron spectral power flux  ~ νF(ν) vs ENERGY (Uchiyama et al. 2005)
+    #plot(
+    #    Energy, P_syn_values, label = L"\nu S_{syn} (\nu)", 
+    #    title = "Synchrotron spectral power flux", titlefontsize = 12, fmt=:jpg,
+    #    xlims=(1.0E-5, 1.0E5), ylims=(1.0E-16, 1.0E-13),
+    #    xaxis=:log10, yaxis=:log10)
+    #xlabel!("Energy [eV]")
+    #ylabel!(L"\nu S_{syn} (\nu) [cgs]")
+    #savefig("syn_spectral_power_flux_FUNC_Energy.png")
 end


### PR DESCRIPTION
I made some update on the synchrotron.jl and other files of the code. I also added the Compton.jl file which is for the synchrotron self-Compton. Here are all the plots I got, I will try to find out how to use subplot later but still wondering what is the best why to do that. 
P.S: I made a mistake on the normalisation of electron density value in the plots that I uploaded on team but the output after fixing that bug are the following.

For all values of the emissivity and the spectral power flux:
![all_ssc_emissivity_all](https://user-images.githubusercontent.com/100141757/175341908-1056b735-350b-40fe-8b7a-71fc9073dbf8.png)
![all_syn_spectral_power_flux_FUNC_Frequency](https://user-images.githubusercontent.com/100141757/175341951-b4220e5f-2104-43f2-aff2-2dedc61b2b92.png)

Using the first method (positive values taken manually):
![I_ssc_emissivity](https://user-images.githubusercontent.com/100141757/175342000-561a7ef4-8aa5-43fa-87e7-337ed961087c.png)
![I_ssc_spectral_power_flux_FUNC_Frequency](https://user-images.githubusercontent.com/100141757/175342022-d07c133d-e07e-4572-9e74-a6f54406c99d.png)

Using the second method (using the for loop and if statement: keeping the positive values and the negative values turned to 1 before using log scale):
![II_ssc_emissivity](https://user-images.githubusercontent.com/100141757/175342041-00486ee2-8703-4ce8-a742-0463d92de43f.png)
![II_ssc_spectral_power_flux_FUNC_Frequency](https://user-images.githubusercontent.com/100141757/175342070-78fbd341-b0fd-4b39-9d12-e144ee441c67.png)

