### PR TITLE
CI: add auto-registration workflow

### DIFF
--- a/.github/workflows/auto-register.yml
+++ b/.github/workflows/auto-register.yml
@@ -1,0 +1,66 @@
+name: Auto-register
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+
+  autoregister:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1.8']
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - run: |
+          git config --global user.email "bot@astro-group-bristol"
+          git config --global user.name "astro-group-bristol[bot]"
+          julia -e '
+          import Pkg
+          Pkg.add(url="https://github.com/GunnarFarneback/LocalRegistry.jl")
+          using LocalRegistry
+          Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/astro-group-bristol/AstroRegistry/"))
+          register(pwd(), registry="AstroRegistry", push=false)
+          '
+      - name: Create new branch
+        run: |
+          cd ~/.julia/registries/AstroRegistry
+          git checkout -b "bot/discjetconnections"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.SECRET_PR_TOKEN }}
+          repository: "astro-group-bristol/AstroRegistry"
+          directory: "/home/runner/.julia/registries/AstroRegistry"
+          branch: "bot/discjetconnections"
+      - name: Create pull request
+        run: |
+          cd ~/.julia/registries/AstroRegistry
+          gh pr create -B main \
+            --title "New Version: DiscJetConnections" \
+            --body "Automated pull request." \
+            -H "bot/discjetconnections"
+        env:
+            GITHUB_TOKEN: ${{ secrets.SECRET_PR_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiscJetConnections"
 uuid = "9ec08b66-6ee8-447e-945d-4d196407106a"
 authors = ["GloriaRAH <gloria.raharimbolamena@bristol.ac.uk>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
I've made a hacky little workflow that automatically re-registers Julia packages into our AstroRegistry whenever a push to the main branch is made. I've been slowly going round adding it to every project in the registry, so this is exactly what this PR does.

To get the pull-request system to work correctly, I had to create a GitHub Personal Access Token under my account (in the future, this will be an Organisation one instead of a personal one, but GitHub is still working on rolling that out), so the PRs on AstroRegistry _appear_ to be made from my account, just incase you are wondering.

The registration fails if a push is made but the version number in Project.toml isn't changed, as a heads up.

@GloriaRAH if you would like to have your package continuously updated in the registry, feel free to merge! The script should be relatively bug free 👍 