### PR TITLE
feat(ci): add registry to docs workflow

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,10 +10,11 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
+      - run: julia -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/astro-group-bristol/AstroRegistry/"))'
       - run: julia --project=. -e 'using Pkg; Pkg.activate("."); Pkg.instantiate()'
       - run: julia --project=. docs/make.jl
         env:


### PR DESCRIPTION
The documentation workflow is failing since it cannot resolve SpectralFitting as a package. This is because the workflow doesn't yet use the AstroRegistry.

Updated to add the registry before initializing the package.