### PR TITLE
Pluto interactive notebooks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SyncSSCModel"
 uuid = "9ec08b66-6ee8-447e-945d-4d196407106a"
 authors = ["GloriaRAH <gloria.raharimbolamena@bristol.ac.uk>"]
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -14,6 +14,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SpectralFitting = "f2c56810-742e-4b72-8bf4-27af3bb81a12"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SyncSSCModel"
 uuid = "9ec08b66-6ee8-447e-945d-4d196407106a"
 authors = ["GloriaRAH <gloria.raharimbolamena@bristol.ac.uk>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -13,6 +13,7 @@ OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SpectralFitting = "f2c56810-742e-4b72-8bf4-27af3bb81a12"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SyncSSCModel"
 uuid = "9ec08b66-6ee8-447e-945d-4d196407106a"
 authors = ["GloriaRAH <gloria.raharimbolamena@bristol.ac.uk>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,20 @@
 name = "SyncSSCModel"
 uuid = "9ec08b66-6ee8-447e-945d-4d196407106a"
 authors = ["GloriaRAH <gloria.raharimbolamena@bristol.ac.uk>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SpectralFitting = "f2c56810-742e-4b72-8bf4-27af3bb81a12"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,20 @@ julia>] dev --local https://github.com/astro-group-bristol/SyncSSCModel.jl
 julia>] instantiate
 ```
 
-## Simple fit example
+## Simple fit examples
 Find the example scripts in [examples](examples). Two files are required for each source.
 - The first file contains the Julia script to do the fitting (e.g. [PicA.jl](examples/PicA.jl)). You can enter parameter values according to the source and define which parameters to freeze and which to fit.
 - The second file is a `.txt` file (e.g. [PicA.txt](examples/PicA.txt)) where you put all your observation data sets in a logarithmic scale. The first column is for the frequency $\log_{10} \nu$ in Hz, and the second column is for the spectral power flux $\log_{10} \nu F_{\nu}$ in cgs units $\text{erg cm}^{-2} \text{s}^{-1}$.
+- There are example fits to Pictor A ([PicA.jl](examples/PicA.jl)) and PKS 0637-752 ([PKS0637-752.jl](examples/PKS0637-752.jl)).
+
+## Pluto interactive examples
+You can use [Pluto](https://plutojl.org/) to interactively run the examples.
+
+```julia
+import Pkg; Pkg.add("Pluto")
+import Pluto; Pluto.run()
+```
+
+Then open the file [examples/interactivePicA.jl](examples/interactivePicA.jl) or [examples/interactivePKS.jl](examples/interactivePKS.jl) in Pluto, in your web browser.
+
+*Note*: the examples requires the [PlutoUI.jl](https://github.com/JuliaPluto/PlutoUI.jl) module.

--- a/examples/PKS0637-752.jl
+++ b/examples/PKS0637-752.jl
@@ -9,15 +9,15 @@ using Plots
 # specifies which paramters are free
 function PKSSSCModel(;
     K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
-    log_B = FitParam(log10(1.25E-5), lower_limit = -6.0, upper_limit = -3.0),
+    log_B = FitParam(log10(1.25E-5), lower_limit = -8.0, upper_limit = -3.0),
     n_e0 = FitParam(19.0, lower_limit = 0.0, upper_limit = 1.0E2),
     log_radius = FitParam(log10(1.0E22), lower_limit = 21.0, upper_limit = 23.0),
     Γ = FitParam(2.0),
     log_γ_min = FitParam(log10(2.5E3), lower_limit = 1.0),
     log_γ_max = FitParam(log10(4.0E6), upper_limit = 8.0),
     p = FitParam(2.6, lower_limit = 2.0, upper_limit = 3.5),
-    log_dL = FitParam(log10(1.26E28), lower_limit=23.0, upper_limit=29.0),
-    θ = FitParam(60.0 * pi / 180.0),
+    log_dL = FitParam(log10(1.26E28), lower_limit = 23.0, upper_limit = 29.0),
+    θ = FitParam(60.0 * pi / 180.0, lower_limit = 30*pi/180, upper_limit = 80*pi/180),
     z = FitParam(0.651),
 )
     SSCModel{

--- a/examples/PKS0637-752.jl
+++ b/examples/PKS0637-752.jl
@@ -12,12 +12,12 @@ function PKSSSCModel(;
     K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
     B = FitParam(1.25E-5, lower_limit = 0.0, upper_limit = 1.0E-3),
     n_e0 = FitParam(19.0, lower_limit = 0.0, upper_limit = 1.0E2),
-    radius = FitParam(1.0E22, lower_limit = 1.0E21, upper_limit = 1.0E23),
+    log_radius = FitParam(log10(1.0E22), lower_limit = 21.0, upper_limit = 23.0),
     Γ = FitParam(2.0),
     γ_min = FitParam(2.5E3),
     γ_max = FitParam(4.0E6),
     p = FitParam(2.6, lower_limit = 2.0, upper_limit = 3.5),
-    dL = FitParam(1.26E28, lower_limit = 1.0E27, upper_limit = 1.0E29),
+    log_dL = FitParam(log10(1.26E28), lower_limit=23.0, upper_limit=29.0),
     θ = FitParam(60.0 * pi / 180.0),
     z = FitParam(0.651),
 )
@@ -25,7 +25,7 @@ function PKSSSCModel(;
         typeof(K),
         # SpectralFitting.FreeParameters{(:K, :B, :p, :radius, :θ, :dL, :z, :n_e0)},
         # SpectralFitting.FreeParameters{(:K, :B, :p, :θ, :n_e0,)},
-        SpectralFitting.FreeParameters{(:B, :n_e0)},
+        SpectralFitting.FreeParameters{(:B, :n_e0, :log_dL)},
     }(
         K,
         B,
@@ -34,9 +34,9 @@ function PKSSSCModel(;
         γ_min,
         γ_max,
         Γ,
-        radius,
+        log_radius,
         θ,
-        dL,
+        log_dL,
         z,
     )
 end

--- a/examples/PKS0637-752.jl
+++ b/examples/PKS0637-752.jl
@@ -3,19 +3,18 @@
 using SyncSSCModel
 using SpectralFitting
 using Plots
-using Revise
 
 # define the model we want to fit
 # includes default parameter values
 # specifies which paramters are free
 function PKSSSCModel(;
     K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
-    B = FitParam(1.25E-5, lower_limit = 0.0, upper_limit = 1.0E-3),
+    log_B = FitParam(log10(1.25E-5), lower_limit = -6.0, upper_limit = -3.0),
     n_e0 = FitParam(19.0, lower_limit = 0.0, upper_limit = 1.0E2),
     log_radius = FitParam(log10(1.0E22), lower_limit = 21.0, upper_limit = 23.0),
     Γ = FitParam(2.0),
-    γ_min = FitParam(2.5E3),
-    γ_max = FitParam(4.0E6),
+    log_γ_min = FitParam(log10(2.5E3), lower_limit = 1.0),
+    log_γ_max = FitParam(log10(4.0E6), upper_limit = 8.0),
     p = FitParam(2.6, lower_limit = 2.0, upper_limit = 3.5),
     log_dL = FitParam(log10(1.26E28), lower_limit=23.0, upper_limit=29.0),
     θ = FitParam(60.0 * pi / 180.0),
@@ -23,36 +22,10 @@ function PKSSSCModel(;
 )
     SSCModel{
         typeof(K),
-        # SpectralFitting.FreeParameters{(:K, :B, :p, :radius, :θ, :dL, :z, :n_e0)},
-        # SpectralFitting.FreeParameters{(:K, :B, :p, :θ, :n_e0,)},
-        SpectralFitting.FreeParameters{(:B, :n_e0, :log_dL)},
+        SpectralFitting.FreeParameters{(:log_B, :n_e0, :θ)},
     }(
-        K,
-        B,
-        n_e0,
-        p,
-        γ_min,
-        γ_max,
-        Γ,
-        log_radius,
-        θ,
-        log_dL,
-        z,
+        K, log_B, n_e0, p, log_γ_min, log_γ_max, Γ, log_radius, θ, log_dL, z,
     )
-end
-
-νrange =  10 .^ collect(range(7, 26, 100))
-
-model = PKSSSCModel()
-flux = invokemodel(νrange, model)
-# flux = invokemodel!(flux, νrange, model)
-
-# find indices where flux is greater than 0
-indices = findall(x -> x > 0, flux)
-
-begin
-    p = plot(νrange[indices], flux[indices], xscale=:log10, yscale=:log10, xlabel="ν (Hz)", ylabel="Flux (units)", label = "Model", legend = :topleft)
-    display(p)
 end
 
 # read in the data values
@@ -79,38 +52,24 @@ dataset = SimpleDataset(
     y_err = 0.1 .* (10 .^ data[2, :]),
 )
 
-# Overplot dataset as large points, colored red, without lines
-plot!(dataset.x, dataset.y, seriestype = :scatter, markersize = 3, markerstrokewidth = 0, mc=:red, label = "Data")
-
-# create an instance of the model
-# model = SSCModel()
-
-# νrange =  10 .^ collect(range(7, 26, 100))
-# f = invokemodel(νrange, model)
-
-# plot(νrange, f)
-
-# begin
-    # base case
-    # plot!(dataset.x, dataset.y)
-    # plot!(νrange, f)
-    # display(p)
-# end
-
+# define the fitting problem
+model = PKSSSCModel()
 prob = FittingProblem(model, dataset)
 
-# LevenbergMarquadt version of fitting
-res = fit(prob, LevenbergMarquadt()) # , autodiff = :finite)
+# fit using Levenberg Marquadt
+res = fit(prob, LevenbergMarquadt(), autodiff = :finite)
 
-# NelderMead version of fitting
+# fit using Nelder Mead
 # using OptimizationOptimJL
 # res = fit(prob, ChiSquared(), NelderMead())
 
+# plot the data and the best fit model
 plot(dataset.x, dataset.y, seriestype = :scatter, xscale = :log10, yscale = :log10, mc=:red, xrange=(1e7, 1e26), yrange=(1e-17, 5e-13), legend = :topleft, label = "Data")
-# plot!(res, lc=:blue)
 
+νrange =  10 .^ collect(range(7, 26, 100))
 f = invokemodel(νrange, model, res.u)
-plot!(νrange, f, lc=:blue, label = "Best fit model")
+nonzero = findall(x -> x > 0.0, f)
+plot!(νrange[nonzero], f[nonzero], lc=:blue, label = "Best fit model")
 
 # print the result prettily
 display(res)

--- a/examples/PicA.jl
+++ b/examples/PicA.jl
@@ -3,14 +3,13 @@
 using SyncSSCModel
 using SpectralFitting
 using Plots
-using Revise
 
 # define the model we want to fit
 # includes default parameter values
 # specifies which paramters are free
 function PicASSCModel(;
     K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
-    B = FitParam(3.3E-5, lower_limit = 0.0, upper_limit = 1.0E-2),
+    log_B = FitParam(log10(3.3E-5), lower_limit = -6.0, upper_limit = -2.0),
     n_e0 = FitParam(5.3, lower_limit = 0.0, upper_limit = 1.0E2),
     log_radius = FitParam(log10(7.7E20), lower_limit = 20.0, upper_limit = 22.0),
     Γ = FitParam(1.0),
@@ -24,11 +23,11 @@ function PicASSCModel(;
     SSCModel{
         typeof(K),
         # SpectralFitting.FreeParameters{(:K, :B, :p, :radius, :θ, :dL, :z, :n_e0)},
-        # SpectralFitting.FreeParameters{(:K, :B, :p, :θ, :n_e0,)},
-        SpectralFitting.FreeParameters{(:B, :p, :n_e0, :log_radius, :log_dL)},
+        # SpectralFitting.FreeParameters{(:K, :log_B, :p, :θ, :n_e0,)},
+        SpectralFitting.FreeParameters{(:log_B, :n_e0,)},
     }(
         K,
-        B,
+        log_B,
         n_e0,
         p,
         γ_min,
@@ -46,6 +45,9 @@ end
 model = PicASSCModel()
 flux = invokemodel(νrange, model)
 # flux = invokemodel!(flux, νrange, model)
+
+# find inices where flux is non zero
+# nonzero = findall(x -> x > 0.0, flux)
 
 begin
     p = plot(νrange[1:end-1], flux[1:end-1], xscale=:log10, yscale=:log10, xlabel="ν (Hz)", ylabel="Flux (units)", label = "Model", legend = :topleft)

--- a/examples/PicA.jl
+++ b/examples/PicA.jl
@@ -8,10 +8,10 @@ using Plots
 # includes default parameter values
 # specifies which paramters are free
 function PicASSCModel(;
-    K = FitParam(1.0),
-    B = FitParam(3.3E-5),
-    n_e0 = FitParam(5.3),
-    radius = FitParam(7.7E20),
+    K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
+    B = FitParam(3.3E-5, lower_limit = 0.0, upper_limit = 1.0E-2),
+    n_e0 = FitParam(5.3, lower_limit = 0.0, upper_limit = 1.0E2),
+    radius = FitParam(7.7E20, lower_limit = 1.0E20, upper_limit = 1.0E22),
     Γ = FitParam(1.0),
     γ_min = FitParam(8.7E1),
     γ_max = FitParam(1.0E6),
@@ -23,7 +23,8 @@ function PicASSCModel(;
     SSCModel{
         typeof(K),
         # SpectralFitting.FreeParameters{(:K, :B, :p, :radius, :θ, :dL, :z, :n_e0)},
-        SpectralFitting.FreeParameters{(:K, :B, :p, :θ, :n_e0,)},
+        # SpectralFitting.FreeParameters{(:K, :B, :p, :θ, :n_e0,)},
+        SpectralFitting.FreeParameters{(:K, :B, :p, :n_e0,)},
     }(
         K,
         B,
@@ -96,11 +97,12 @@ prob = FittingProblem(model, dataset)
 res = fit(prob, LevenbergMarquadt(), autodiff = :finite)
 # using OptimizationOptimJL
 # res = fit(prob, ChiSquared(), NelderMead())
-# print the result prettily
-display(res)
 
 plot(dataset.x, dataset.y, seriestype = :scatter, xscale = :log10, yscale = :log10, mc=:red, xrange=(1e7, 1e26), yrange=(1e-14, 1e-11), legend = :topleft, label = "Data")
 # plot!(res, lc=:blue)
 
 f = invokemodel(νrange, model, res.u)
 plot!(νrange, f, lc=:blue, label = "Best fit model")
+
+# print the result prettily
+display(res)

--- a/examples/PicA.jl
+++ b/examples/PicA.jl
@@ -3,6 +3,7 @@
 using SyncSSCModel
 using SpectralFitting
 using Plots
+using Revise
 
 # define the model we want to fit
 # includes default parameter values

--- a/examples/PicA.jl
+++ b/examples/PicA.jl
@@ -12,12 +12,12 @@ function PicASSCModel(;
     K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
     B = FitParam(3.3E-5, lower_limit = 0.0, upper_limit = 1.0E-2),
     n_e0 = FitParam(5.3, lower_limit = 0.0, upper_limit = 1.0E2),
-    radius = FitParam(7.7E20, lower_limit = 1.0E20, upper_limit = 1.0E22),
+    log_radius = FitParam(log10(7.7E20), lower_limit = 20.0, upper_limit = 22.0),
     Γ = FitParam(1.0),
     γ_min = FitParam(8.7E1),
     γ_max = FitParam(1.0E6),
     p = FitParam(2.48),
-    dL = FitParam(4.752E26),
+    log_dL = FitParam(log10(4.752E26), lower_limit = 26.0, upper_limit = 28.0),
     θ = FitParam(23.0 * pi / 180.0),
     z = FitParam(0.035),
 )
@@ -25,7 +25,7 @@ function PicASSCModel(;
         typeof(K),
         # SpectralFitting.FreeParameters{(:K, :B, :p, :radius, :θ, :dL, :z, :n_e0)},
         # SpectralFitting.FreeParameters{(:K, :B, :p, :θ, :n_e0,)},
-        SpectralFitting.FreeParameters{(:K, :B, :p, :n_e0,)},
+        SpectralFitting.FreeParameters{(:B, :p, :n_e0, :log_radius, :log_dL)},
     }(
         K,
         B,
@@ -34,9 +34,9 @@ function PicASSCModel(;
         γ_min,
         γ_max,
         Γ,
-        radius,
+        log_radius,
         θ,
-        dL,
+        log_dL,
         z,
     )
 end

--- a/examples/interactiveModels.jl
+++ b/examples/interactiveModels.jl
@@ -1,0 +1,142 @@
+### A Pluto.jl notebook ###
+# v0.19.25
+
+using Markdown
+using InteractiveUtils
+
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+end
+
+# ╔═╡ 4a510b9e-213a-452e-b14b-3a8a12383c19
+using Pkg; Pkg.activate("../.")
+
+# ╔═╡ d2304800-21d3-495c-ad26-0f994e7328e9
+begin
+	using SyncSSCModel
+	using SpectralFitting
+	using Plots
+	gr()
+	using PlutoUI
+end
+
+# ╔═╡ cbf7004c-e681-464d-ba56-677e312bf3b5
+md"""
+# Testing interactive models in Pluto.jl
+"""
+
+# ╔═╡ 14dff0ad-3a72-48ab-ab62-a1386a8530f5
+md"""
+Interactive exploration of the SSC model for Pictor A
+"""
+
+# ╔═╡ bd0e25a0-b015-40e3-942f-219286a6ef90
+md"""
+Define SSC model
+"""
+
+# ╔═╡ 0ac10751-444f-423b-a4e7-5839e29be045
+function PicASSCModel(;
+    K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
+    log_B = FitParam(-4.6096, lower_limit = -6.0, upper_limit = -2.0),
+    n_e0 = FitParam(4.9715, lower_limit = 1.0, upper_limit = 10.0),
+    log_radius = FitParam(log10(7.7E20), lower_limit = 20.0, upper_limit = 22.0),
+    Γ = FitParam(1.0),
+    γ_min = FitParam(8.7E1),
+    γ_max = FitParam(1.0E6),
+    p = FitParam(2.48),
+    log_dL = FitParam(log10(4.752E26), lower_limit = 26.0, upper_limit = 28.0),
+    θ = FitParam(23.0 * pi / 180.0),
+    z = FitParam(0.035),
+)
+    SSCModel{
+        typeof(K),
+        # SpectralFitting.FreeParameters{(:K, :B, :p, :n_e0,)},
+		SpectralFitting.FreeParameters{(:log_B, :n_e0,)},
+    }(
+        K, log_B, n_e0, p, γ_min, γ_max, Γ, log_radius, θ, log_dL, z,
+    )
+end
+
+# ╔═╡ 7c509230-b97e-4ed3-b46e-8151625096d6
+md"""
+Define Pictor A dataset of flux densities at different frequencies
+"""
+
+# ╔═╡ ec2cfccf-c976-4363-8de4-dac4b4f442ae
+begin
+    lines = readlines(@__DIR__() * "/PicA.txt")
+    number_expr = r"(-?\d*\.\d*)"
+    search_expr = r"^" * number_expr * r"\s+" * number_expr
+    data_stacked = map(filter(!isnothing, match.(search_expr, lines))) do m
+        parse.(Float64, m.captures)
+    end
+    # sort just for coherence
+    sort!(data_stacked)
+    # flatten array
+    data = reduce(hcat, data_stacked)
+end
+
+# ╔═╡ a980821a-e07d-4983-a60c-1a47874f52db
+dataset = SimpleDataset(
+    "PicAdata",
+    10 .^ data[1, :],
+    10 .^ data[2, :],
+    x_units = SpectralFitting.SpectralUnits.u"Hz",
+    x_err = 0.05 .* (10 .^ data[1, :]),
+	
+    y_err = 0.1 .* (10 .^ data[2, :]),
+)
+
+# ╔═╡ 53a26f8a-89de-4e1d-bfc1-9a0ea676bcbb
+md"""
+Adjustable model parameters
+"""
+
+# ╔═╡ 2b095fe7-f16d-4d30-a0db-764e087e897f
+@bind var_n_e0 Slider(0.1:0.1:10, default=5.3)
+
+# ╔═╡ 2728a610-48dd-40a0-9f19-306d9b33e80f
+@bind var_log_B Slider(-6.0:0.1:-2.0, default=-4.5)
+
+# ╔═╡ a022f9ca-9a3d-46c4-af36-053a1ecd3588
+print("Density n_e0 = ", var_n_e0, " Magnetic field B = ", var_log_B)
+
+# ╔═╡ 1175735a-22f1-4662-8029-8983ad747318
+md"""
+Evaluate model, plot model, overplot data
+"""
+
+# ╔═╡ 7efde37e-52ee-4239-846d-08b33fc9d5fb
+begin
+	νrange =  10 .^ collect(range(7, 26, 100))
+	model = PicASSCModel()
+	model_free_pars = [var_log_B, var_n_e0]
+	flux = invokemodel(νrange, model, model_free_pars)
+	nonzero = findall(x -> x > 0.0, flux)
+	plot(νrange[nonzero], flux[nonzero], xscale=:log10, yscale=:log10, xlabel="ν (Hz)", ylabel="Flux (units)", label = "Model", legend = :topleft)
+	plot!(dataset.x, dataset.y, seriestype = :scatter, markersize = 3, markerstrokewidth = 0, mc=:red, label = "Data")
+end
+
+# ╔═╡ Cell order:
+# ╟─cbf7004c-e681-464d-ba56-677e312bf3b5
+# ╟─14dff0ad-3a72-48ab-ab62-a1386a8530f5
+# ╠═4a510b9e-213a-452e-b14b-3a8a12383c19
+# ╠═d2304800-21d3-495c-ad26-0f994e7328e9
+# ╟─bd0e25a0-b015-40e3-942f-219286a6ef90
+# ╠═0ac10751-444f-423b-a4e7-5839e29be045
+# ╟─7c509230-b97e-4ed3-b46e-8151625096d6
+# ╠═ec2cfccf-c976-4363-8de4-dac4b4f442ae
+# ╠═a980821a-e07d-4983-a60c-1a47874f52db
+# ╟─53a26f8a-89de-4e1d-bfc1-9a0ea676bcbb
+# ╠═2b095fe7-f16d-4d30-a0db-764e087e897f
+# ╠═2728a610-48dd-40a0-9f19-306d9b33e80f
+# ╠═a022f9ca-9a3d-46c4-af36-053a1ecd3588
+# ╟─1175735a-22f1-4662-8029-8983ad747318
+# ╠═7efde37e-52ee-4239-846d-08b33fc9d5fb

--- a/examples/interactivePicA.jl
+++ b/examples/interactivePicA.jl
@@ -1,0 +1,144 @@
+### A Pluto.jl notebook ###
+# v0.19.25
+
+using Markdown
+using InteractiveUtils
+
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+end
+
+# ╔═╡ 4a510b9e-213a-452e-b14b-3a8a12383c19
+using Pkg; Pkg.activate("../.")
+
+# ╔═╡ d2304800-21d3-495c-ad26-0f994e7328e9
+begin
+	using SyncSSCModel
+	using SpectralFitting
+	using Plots
+	gr()
+	using PlutoUI
+end
+
+# ╔═╡ cbf7004c-e681-464d-ba56-677e312bf3b5
+md"""
+# Testing interactive models in Pluto.jl
+"""
+
+# ╔═╡ 14dff0ad-3a72-48ab-ab62-a1386a8530f5
+md"""
+Interactive exploration of the SSC model for Pictor A
+"""
+
+# ╔═╡ bd0e25a0-b015-40e3-942f-219286a6ef90
+md"""
+Define SSC model
+"""
+
+# ╔═╡ 0ac10751-444f-423b-a4e7-5839e29be045
+function PicASSCModel(;
+    K = FitParam(1.0, lower_limit = 0.5, upper_limit = 2.0),
+    log_B = FitParam(-4.6096, lower_limit = -6.0, upper_limit = -2.0),
+    n_e0 = FitParam(4.9715, lower_limit = 1.0, upper_limit = 10.0),
+    log_radius = FitParam(log10(7.7E20), lower_limit = 20.0, upper_limit = 22.0),
+    Γ = FitParam(1.0),
+    log_γ_min = FitParam(log10(8.7E1)),
+    log_γ_max = FitParam(log10(1.0E6), lower_limit = 4.0, upper_limit = 8.0),
+    p = FitParam(2.48),
+    log_dL = FitParam(log10(4.752E26), lower_limit = 26.0, upper_limit = 28.0),
+    θ = FitParam(23.0 * pi / 180.0),
+    z = FitParam(0.035),
+)
+    SSCModel{
+        typeof(K),
+		SpectralFitting.FreeParameters{(:log_B, :n_e0, :log_γ_max)},
+    }(
+        K, log_B, n_e0, p, log_γ_min, log_γ_max, Γ, log_radius, θ, log_dL, z,
+    )
+end
+
+# ╔═╡ 7c509230-b97e-4ed3-b46e-8151625096d6
+md"""
+Define Pictor A dataset of flux densities at different frequencies
+"""
+
+# ╔═╡ ec2cfccf-c976-4363-8de4-dac4b4f442ae
+begin
+    lines = readlines(@__DIR__() * "/PicA.txt")
+    number_expr = r"(-?\d*\.\d*)"
+    search_expr = r"^" * number_expr * r"\s+" * number_expr
+    data_stacked = map(filter(!isnothing, match.(search_expr, lines))) do m
+        parse.(Float64, m.captures)
+    end
+    # sort just for coherence
+    sort!(data_stacked)
+    # flatten array
+    data = reduce(hcat, data_stacked)
+end
+
+# ╔═╡ a980821a-e07d-4983-a60c-1a47874f52db
+dataset = SimpleDataset(
+    "PicAdata",
+    10 .^ data[1, :],
+    10 .^ data[2, :],
+    x_units = SpectralFitting.SpectralUnits.u"Hz",
+    x_err = 0.05 .* (10 .^ data[1, :]),
+    y_err = 0.1 .* (10 .^ data[2, :]),
+)
+
+# ╔═╡ 53a26f8a-89de-4e1d-bfc1-9a0ea676bcbb
+md"""
+Adjustable model parameters
+"""
+
+# ╔═╡ 2b095fe7-f16d-4d30-a0db-764e087e897f
+@bind var_n_e0 Slider(0.1:0.1:10, default=5.3)
+
+# ╔═╡ 2728a610-48dd-40a0-9f19-306d9b33e80f
+@bind var_log_B Slider(-6.0:0.1:-2.0, default=-4.5)
+
+# ╔═╡ f3b1babf-c7ad-4f66-91be-4b14b3c24ba8
+@bind var_log_γ_max Slider(4.0:0.1:8.0, default=6.0)
+
+# ╔═╡ a022f9ca-9a3d-46c4-af36-053a1ecd3588
+print("Density n_e0 = ", var_n_e0, " Magnetic field B = ", var_log_B, " log_10(γ_max) = ", var_log_γ_max)
+
+# ╔═╡ 1175735a-22f1-4662-8029-8983ad747318
+md"""
+Evaluate model, plot model, overplot data
+"""
+
+# ╔═╡ 7efde37e-52ee-4239-846d-08b33fc9d5fb
+begin
+	νrange =  10 .^ collect(range(7, 26, 100))
+	model = PicASSCModel()
+	model_free_pars = [var_log_B, var_n_e0, var_log_γ_max]
+	flux = invokemodel(νrange, model, model_free_pars)
+	nonzero = findall(x -> x > 0.0, flux)
+	plot(νrange[nonzero], flux[nonzero], xrange=(1e7, 1e26), yrange=(1e-14, 1e-11), xscale=:log10, yscale=:log10, xlabel="ν (Hz)", ylabel="Flux (units)", label = "Model", legend = :topleft)
+	plot!(dataset.x, dataset.y, seriestype = :scatter, markersize = 3, markerstrokewidth = 0, mc=:red, label = "Data")
+end
+
+# ╔═╡ Cell order:
+# ╟─cbf7004c-e681-464d-ba56-677e312bf3b5
+# ╟─14dff0ad-3a72-48ab-ab62-a1386a8530f5
+# ╠═4a510b9e-213a-452e-b14b-3a8a12383c19
+# ╠═d2304800-21d3-495c-ad26-0f994e7328e9
+# ╟─bd0e25a0-b015-40e3-942f-219286a6ef90
+# ╠═0ac10751-444f-423b-a4e7-5839e29be045
+# ╟─7c509230-b97e-4ed3-b46e-8151625096d6
+# ╠═ec2cfccf-c976-4363-8de4-dac4b4f442ae
+# ╠═a980821a-e07d-4983-a60c-1a47874f52db
+# ╟─53a26f8a-89de-4e1d-bfc1-9a0ea676bcbb
+# ╠═2b095fe7-f16d-4d30-a0db-764e087e897f
+# ╠═2728a610-48dd-40a0-9f19-306d9b33e80f
+# ╠═f3b1babf-c7ad-4f66-91be-4b14b3c24ba8
+# ╠═a022f9ca-9a3d-46c4-af36-053a1ecd3588
+# ╟─1175735a-22f1-4662-8029-8983ad747318
+# ╠═7efde37e-52ee-4239-846d-08b33fc9d5fb

--- a/src/SyncSSCModel.jl
+++ b/src/SyncSSCModel.jl
@@ -60,7 +60,7 @@ end
 Volume Sphere
 """
 function Vb(mps)
-    return((4.0/3.0) * pi * mps.radius^3)
+    return((4.0/3.0) * pi * (10.0^mps.log_radius)^3)
 end
 
 # Major functions
@@ -85,7 +85,7 @@ end
 Synchrotron Flux density
 """
 function S_syn(ϵ, mps)
-    return((δ(mps)^3 * (1.0+mps.z) * Vb(mps) * j_syn(ϵ*(1.0+mps.z)/δ(mps), mps)) / mps.dL^2)
+    return((δ(mps)^3 * (1.0+mps.z) * Vb(mps) * j_syn(ϵ*(1.0+mps.z)/δ(mps), mps)) / (10.0^mps.log_dL)^2)
 end
 """
 Synchrotron Spectral Power Flux
@@ -105,7 +105,7 @@ Synchrotron Self-Compton emissivity
 function j_ssc(ϵ, mps)
     Σ_c = min(ϵ^-1, ϵ/mps.γ_min^2, ϵ_B(mps)*mps.γ_max^2) / max(ϵ_B(mps)*mps.γ_min^2, ϵ/mps.γ_max^2)
     if Σ_c > 1.0
-        return(((c_cgs_f * σ_e_cgs_f^2 * mps.n_e0^2 * u_B(mps) * mps.radius) / (9.0 * pi * ϵ_B(mps))) * (ϵ/ϵ_B(mps))^-α(mps) * log(Σ_c))
+        return(((c_cgs_f * σ_e_cgs_f^2 * mps.n_e0^2 * u_B(mps) * (10.0^mps.log_radius)) / (9.0 * pi * ϵ_B(mps))) * (ϵ/ϵ_B(mps))^-α(mps) * log(Σ_c))
     else
         return(0.0)
     end
@@ -117,7 +117,7 @@ function P_ssc(ϵ, mps)
 
     Σ_c = min(δ(mps)/(ϵ*(1.0+mps.z)), mps.γ_max^2 * ϵ_B(mps), ϵ*(1.0+mps.z)/(δ(mps)*mps.γ_min^2)) / max(mps.γ_min^2 * ϵ_B(mps), ϵ*(1+mps.z)/(δ(mps)*mps.γ_max^2))
     if Σ_c > 1.0
-        return(((δ(mps))^(3.0+α(mps)) * (c_cgs_f*σ_e_cgs_f^2*mps.n_e0^2*u_B(mps)*mps.radius*Vb(mps)) * (1.0+mps.z)^(1.0-α(mps)) * (ϵ/ϵ_B(mps))^(1.0-α(mps)) * log(Σ_c)) / (9.0*pi*mps.dL^2))
+        return(((δ(mps))^(3.0+α(mps)) * (c_cgs_f*σ_e_cgs_f^2*mps.n_e0^2*u_B(mps)*(10.0^mps.log_radius)*Vb(mps)) * (1.0+mps.z)^(1.0-α(mps)) * (ϵ/ϵ_B(mps))^(1.0-α(mps)) * log(Σ_c)) / (9.0*pi*(10.0^mps.log_dL)^2))
     else
         return(0.0)
     end
@@ -177,12 +177,12 @@ end
     γ_max::T
     "Bulk Lorentz Factor"
     Γ::T
-    "Radius of emitting Region"
-    radius::T
+    "log_10(Radius of emitting Region)"
+    log_radius::T
     "Angle (radians) between the direction of the blob's motion and the direction to the observer"
     θ::T
-    "Luminosity distance"
-    dL::T
+    "log_10(Luminosity distance)"
+    log_dL::T
     "Redshift"
     z::T
 end

--- a/src/SyncSSCModel.jl
+++ b/src/SyncSSCModel.jl
@@ -68,7 +68,7 @@ end
 Electron density distribution
 """
 function dn_e(ϵ, mps)
-    if (γ(ϵ, mps) < mps.γ_min) || (γ(ϵ, mps) > mps.γ_max)
+    if (γ(ϵ, mps) < (10.0^mps.log_γ_min)) || (γ(ϵ, mps) > (10.0^mps.log_γ_max))
         dn_e = 0.0
     else
         dn_e = mps.n_e0 * γ(ϵ, mps)^-mps.p
@@ -103,7 +103,7 @@ end
 Synchrotron Self-Compton emissivity
 """
 function j_ssc(ϵ, mps)
-    Σ_c = min(ϵ^-1, ϵ/mps.γ_min^2, ϵ_B(mps)*mps.γ_max^2) / max(ϵ_B(mps)*mps.γ_min^2, ϵ/mps.γ_max^2)
+    Σ_c = min(ϵ^-1, ϵ/(10.0^mps.log_γ_min)^2, ϵ_B(mps)*(10.0^mps.log_γ_max)^2) / max(ϵ_B(mps)*(10.0^mps.log_γ_min)^2, ϵ/(10.0^mps.log_γ_max)^2)
     if Σ_c > 1.0
         return(((c_cgs_f * σ_e_cgs_f^2 * mps.n_e0^2 * u_B(mps) * (10.0^mps.log_radius)) / (9.0 * pi * ϵ_B(mps))) * (ϵ/ϵ_B(mps))^-α(mps) * log(Σ_c))
     else
@@ -115,7 +115,7 @@ Synchrotron Self-Compton Flux density
 """
 function P_ssc(ϵ, mps)
 
-    Σ_c = min(δ(mps)/(ϵ*(1.0+mps.z)), mps.γ_max^2 * ϵ_B(mps), ϵ*(1.0+mps.z)/(δ(mps)*mps.γ_min^2)) / max(mps.γ_min^2 * ϵ_B(mps), ϵ*(1+mps.z)/(δ(mps)*mps.γ_max^2))
+    Σ_c = min(δ(mps)/(ϵ*(1.0+mps.z)), (10.0^mps.log_γ_max)^2 * ϵ_B(mps), ϵ*(1.0+mps.z)/(δ(mps)*(10.0^mps.log_γ_min)^2)) / max((10.0^mps.log_γ_min)^2 * ϵ_B(mps), ϵ*(1+mps.z)/(δ(mps)*(10.0^mps.log_γ_max)^2))
     if Σ_c > 1.0
         return(((δ(mps))^(3.0+α(mps)) * (c_cgs_f*σ_e_cgs_f^2*mps.n_e0^2*u_B(mps)*(10.0^mps.log_radius)*Vb(mps)) * (1.0+mps.z)^(1.0-α(mps)) * (ϵ/ϵ_B(mps))^(1.0-α(mps)) * log(Σ_c)) / (9.0*pi*(10.0^mps.log_dL)^2))
     else
@@ -171,10 +171,10 @@ end
     n_e0::T
     "Power law index"
     p::T
-    "Minimum Lorentz Factor"
-    γ_min::T
-    "Maximum Lorentz Factor"
-    γ_max::T
+    "log_10(Minimum Lorentz Factor)"
+    log_γ_min::T
+    "log_10(Maximum Lorentz Factor)"
+    log_γ_max::T
     "Bulk Lorentz Factor"
     Γ::T
     "log_10(Radius of emitting Region)"

--- a/src/SyncSSCModel.jl
+++ b/src/SyncSSCModel.jl
@@ -23,14 +23,14 @@ const σ_e_cgs_f = qconvert(Float64, uconvert(u"cm^2", σ_e))
 Cyclotron energy in units of m_e*c^2
 """
 function ϵ_B(mps)
-    return(mps.B/4.414E13)
+    return(10.0^mps.log_B/4.414E13)
 end
 
 """
 Magnetic field energy density
 """
 function u_B(mps)
-    return((mps.B)^2/(8.0*pi))
+    return((10.0^mps.log_B)^2/(8.0*pi))
 end
 
 """
@@ -165,8 +165,8 @@ end
     # need this field for additive models
     "Normalisation."
     K::T
-    "Magnetic field strength in Gauss"
-    B::T
+    "log_10(Magnetic field strength in Gauss)"
+    log_B::T
     "Normalisation of electron density in cm^-3"
     n_e0::T
     "Power law index"


### PR DESCRIPTION
- Added two interactive Pluto notebooks. There are sliders to change model parameters so you can see how the models change interactively in real time. This helps find good fits and explore degeneracies between parameters.
- Made some parameters logarithmic as this helps with the dynamic range of the sliders and probably improves fitting too (I didn't figure out why this was necessary).
- Updated the example fits to Pic A and PKS 0637-752.
- Some instructions for the Pluto notebooks in the README.